### PR TITLE
Add FSC licenses to scratch definition, and a couple version updates

### DIFF
--- a/config/demo-recipe.json
+++ b/config/demo-recipe.json
@@ -27,11 +27,11 @@
       "recipeSteps": [
         { 
           "stepName":     "Install FSC Managed Package",
-          "description":  "Installs version 220.6 of the FSC managed package",
+          "description":  "Installs version 224.5 of the FSC managed package",
           "action":       "install-package",
           "options": {
             "packageName":      "Financial Services Cloud (Managed Package), Version 220.6",
-            "packageVersionId": "04t1E000000y9ew"
+            "packageVersionId": "04t1E000000cmtN"
           }
         },
         {

--- a/config/demo-scratch-def.json
+++ b/config/demo-scratch-def.json
@@ -8,7 +8,9 @@
   "features": [
     "Communities",
     "ContactsToMultipleAccounts",
-    "PersonAccounts"
+    "PersonAccounts",
+    "FinancialServicesUser:10",
+    "FinancialServicesCommunityUser:10"    
   ],
   "settings": {
     "orgPreferenceSettings": {

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -3,7 +3,7 @@
     {"path": "sfdx-source/force-app", "default": true}
   ],
   "sfdcLoginUrl": "https://login.salesforce.com",
-  "sourceApiVersion": "45.0",
+  "sourceApiVersion": "48.0",
   "plugins": {
     "sfdxFalcon": {
       "developerAlias"  : "sfdx-isv",


### PR DESCRIPTION
- Added 10 licenses of FSC Standard & FSC Community to scratch def (not all useable with Dev edition, but saves changing them if user adjusts edition to Enterprise) - closes #4 
- Bumped API version in project def to 48.0
- Updated FSC managed package version # & id in recipe